### PR TITLE
add docs to dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,5 @@
 This project aims to develop a suitable application framework for automation of quality control labs in general use.
 The code presented in this repository is part of a bachelor project for six Robottechnology b.sc. Students at Aalborg University.
 
-# Build & Run
-**On Windows:**\
-Open a project after starting Visual Studio and locate the `.csproj` file within the project directory.\
-
-**On Linux:**\
-After cloning the repo, just edit the `.cs` files with whatever editor, build with `dotnet build` and run with `dotnet run` (you need to be in the project root dir to build and run the executable).
-
-**NOTE**:\
-The project runs on .NET Core 9, specifically (as of writing this) 9.0.102.\
-If you do not have this version of .NET Core then your solution would be to update visual studio.
-
-The dotnet sdk (linux) should be updated if you use arch.
-
 # Authors
 Group 662 @ AAU

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,15 @@
 # Documentation
+Project documentation (work in progress)
 
-This is where we keep documentation for the entire project..
+# Build & Run
+**On Windows:**\
+Open a project after starting Visual Studio and locate the `.csproj` file within the project directory.\
+
+**On Linux:**\
+After cloning the repo, just edit the `.cs` files with whatever editor, build with `dotnet build` and run with `dotnet run` (y>
+
+**NOTE**:\
+The project runs on .NET Core 9, specifically (as of writing this) 9.0.102.\
+If you do not have this version of .NET Core then your solution would be to update visual studio.
+
+The dotnet sdk (linux) should be updated if you use arch.


### PR DESCRIPTION
Documentation on how to build and run the project across platforms should be moved to the documentation instead of the initial landing page.

**Keep using the `docs` branch for updating documentation and create PRs when needed on a parent branch, do NOT delete it.**